### PR TITLE
fix(e2e): Set PUBLIC_URL=/ for build so relative paths work

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Start server and run Playwright
         run: |
-          npx serve -s build &
+          PUBLIC_URL=/ npx serve -s build &
           npx playwright test
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
- Set public url to / in e2e workflow so serve will serve the app from the correct relative path

